### PR TITLE
Fix GitHub Pages artifact action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
         run: npm run build
         working-directory: app
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: app/dist
   deploy:


### PR DESCRIPTION
## Summary
- update to `actions/upload-pages-artifact@v3` so GitHub uses the latest `upload-artifact`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863caf955488326898e9b519aea6b14